### PR TITLE
Fix: See highlight code on small screens

### DIFF
--- a/_sass/base/_highlight.scss
+++ b/_sass/base/_highlight.scss
@@ -1,5 +1,6 @@
 .highlight pre { 
     padding: 10px; 
+    overflow: auto;
     margin : 10px 0;
     * {font-size:0.9rem;
     }


### PR DESCRIPTION
+ Add `overflow: auto` .highlight pre
so highlight code on small screens can be see without problem

without  `overflow: auto` you cannot see all the code 😢 

<img src="https://user-images.githubusercontent.com/25267490/81126791-084a1200-8f02-11ea-8965-57451022c1df.png" width="150">




with  `overflow: auto` you can move and see all the code 👍 
<img src="https://user-images.githubusercontent.com/25267490/81126800-0d0ec600-8f02-11ea-9068-b8ca8318076a.gif " width="150">
