### PR TITLE
Open off-site links in a new tab

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -16,7 +16,7 @@
 </div>
 <!-- Tag Navigation -->
 <div id="tag-wrap">
-  <a href="{{ site.url }}/tags">
+  <a href="{{ site.baseurl }}/tags">
     <p class="title">TAGS</p>
   </a>
   {% for tag in site.tags %}
@@ -27,7 +27,7 @@
 </div>
 <!-- Project -->
 <div id="proj-wrap">
-  <a href="{{ site.url }}/portfolio#projects">
+  <a href="{{ site.baseurl }}/portfolio#projects">
     <p class="title">PROJECTS 🙋🏻 </p>
     <hr class="proj-hr">
     {% for _ in site.data.projects %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,7 +15,7 @@
       </a>
       <!-- portfolio -->
       {% when 'portfolio'%}
-      <a href="{{ site.baseurl }}">
+      <a href="{{ site.baseurl }}/">
         <li class="btn-nav">Blog</li>
       </a>
       <a href="{{ site.baseurl }}/tags">
@@ -24,7 +24,7 @@
       <li class="current">Portfolio</li>
       {% else %}
       <!-- others -->
-      <a href="{{ site.baseurl }}">
+      <a href="{{ site.baseurl }}/">
         <li class="current btn-nav">Blog</li>
       </a>
       <a href="{{ site.baseurl }}/tags">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,31 +6,31 @@
       {% case current[0] %}
       {% when 'tags'%}
       <!-- tags -->
-      <a href="{{ site.url }}">
+      <a href="{{ site.baseurl }}/">
         <li class="btn-nav">Blog</li>
       </a>
       <li class="current">Tags</li>
-      <a href="{{ site.url }}/portfolio">
+      <a href="{{ site.baseurl }}/portfolio">
         <li class="btn-nav">Portfolio</li>
       </a>
       <!-- portfolio -->
       {% when 'portfolio'%}
-      <a href="{{ site.url }}">
+      <a href="{{ site.baseurl }}">
         <li class="btn-nav">Blog</li>
       </a>
-      <a href="{{ site.url }}/tags">
+      <a href="{{ site.baseurl }}/tags">
         <li class="btn-nav">Tags</li>
       </a>
       <li class="current">Portfolio</li>
       {% else %}
       <!-- others -->
-      <a href="{{ site.url }}">
+      <a href="{{ site.baseurl }}">
         <li class="current btn-nav">Blog</li>
       </a>
-      <a href="{{ site.url }}/tags">
+      <a href="{{ site.baseurl }}/tags">
         <li class="btn-nav">Tags</li>
       </a>
-      <a href="{{ site.url }}/portfolio">
+      <a href="{{ site.baseurl }}/portfolio">
         <li class="btn-nav">Portfolio</li>
       </a>
       {% endcase %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,7 @@
 {% include head.html %}
 <body>
   <div class="container">
-    {{ content }}
+    {{ content | replace: '<a href="http', '<a rel="nofollow noopener noreferrer" target="_blank" href="http' }}
   </div>
 </body>
 


### PR DESCRIPTION
By using site.baseurl instead of site.url, we can add a line on head.html to open off-site links in a new tab. The noopener and noreferrer are for security additions. :octocat: 

This pull request closes #17 